### PR TITLE
Connector를 controller에 연결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ go.work
 /dist/
 /build/
 opencode-bot
+cnap
 
 # IDE and editor files
 .vscode/

--- a/cmd/cnap/main.go
+++ b/cmd/cnap/main.go
@@ -117,7 +117,7 @@ func runStart(logger *zap.Logger) error {
 
 	// 서버 인스턴스 생성
 	controllerServer := controller.NewController(logger.Named("controller"), repo)
-	connectorServer := connector.NewServer(logger.Named("connector"))
+	connectorServer := connector.NewServer(logger.Named("connector"), controllerServer)
 
 	// 에러 채널
 	errChan := make(chan error, 2)

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -33,6 +33,8 @@ services:
       DATABASE_URL: postgres://${POSTGRES_USER:-cnap}:${POSTGRES_PASSWORD:-cnap}@postgres:5432/${POSTGRES_DB:-cnap}?sslmode=disable
       ENV: ${APP_ENV:-development}
       LOG_LEVEL: ${APP_LOG_LEVEL:-info}
+    env_file:
+      - ../internal/connector/.env
     volumes:
       - app_data:/app/data
     networks:


### PR DESCRIPTION
 Discord 봇이 로컬에서가 아닌 중앙 controller를 통해 에이전트를 관리하도록 리팩터링했습니다. 이를 통해 에이전트 데이터가 Docker 볼륨에 연결된 데이터베이스에   
  영구적으로 저장됩니다.

  주요 변경 사항:
   * 에이전트 관리 로직 이전: Discord connector에 있던 인메모리(in-memory) 에이전트 관리 기능을 controller로 이전했습니다.
   * Docker 설정 수정: Docker 컨테이너가 DISCORD_TOKEN을 포함한 .env 파일을 올바르게 읽을 수 있도록 docker-compose.yml을 업데이트했습니다.
   * .gitignore 업데이트: 빌드 산출물인 cnap 바이너리가 Git 추적에서 제외되도록 추가했습니다.

  이 변경으로 인해 Discord 봇은 이제 상태 비저장(stateless) 방식으로 동작하며, 모든 에이전트 데이터는 애플리케이션 재시작 시에도 유지됩니다.