### PR TITLE
refactor(runner): Package 구조 및 인터페이스 정의 개선

### DIFF
--- a/internal/runner/manager.go
+++ b/internal/runner/manager.go
@@ -1,12 +1,12 @@
-package TaskRunner
+package taskrunner
 
 import (
 	"sync"
 )
 
-// RunnerManager manages TaskRunner instances.
+// RunnerManager manages Runner instances.
 type RunnerManager struct {
-	runners map[string]*TaskRunner
+	runners map[string]*Runner
 	mu      sync.RWMutex
 }
 
@@ -19,18 +19,18 @@ var (
 func GetRunnerManager() *RunnerManager {
 	once.Do(func() {
 		instance = &RunnerManager{
-			runners: make(map[string]*TaskRunner),
+			runners: make(map[string]*Runner),
 		}
 	})
 	return instance
 }
 
-// CreateRunner creates a new TaskRunner and adds it to the manager.
-func (rm *RunnerManager) CreateRunner(taskId string, agent Agent) *TaskRunner {
+// CreateRunner creates a new Runner and adds it to the manager.
+func (rm *RunnerManager) CreateRunner(taskId string, agent AgentInfo) *Runner {
 	rm.mu.Lock()
 	defer rm.mu.Unlock()
 
-	runner := &TaskRunner{
+	runner := &Runner{
 		ID:     taskId,
 		Status: "Pending", // Initial status
 		// Initialize other fields if needed
@@ -39,12 +39,12 @@ func (rm *RunnerManager) CreateRunner(taskId string, agent Agent) *TaskRunner {
 	return runner
 }
 
-// ListRunner returns a list of all TaskRunners.
-func (rm *RunnerManager) ListRunner() *[]TaskRunner {
+// ListRunner returns a list of all Runners.
+func (rm *RunnerManager) ListRunner() *[]Runner {
 	rm.mu.RLock()
 	defer rm.mu.RUnlock()
 
-	runnersList := make([]TaskRunner, 0, len(rm.runners))
+	runnersList := make([]Runner, 0, len(rm.runners))
 	for _, runner := range rm.runners {
 		if runner != nil {
 			runnersList = append(runnersList, *runner)
@@ -53,8 +53,8 @@ func (rm *RunnerManager) ListRunner() *[]TaskRunner {
 	return &runnersList
 }
 
-// DeleteRunner removes a TaskRunner by its ID.
-func (rm *RunnerManager) DeleteRunner(taskId string) *TaskRunner {
+// DeleteRunner removes a Runner by its ID.
+func (rm *RunnerManager) DeleteRunner(taskId string) *Runner {
 	rm.mu.Lock()
 	defer rm.mu.Unlock()
 

--- a/internal/runner/manager_test.go
+++ b/internal/runner/manager_test.go
@@ -1,4 +1,4 @@
-package TaskRunner
+package taskrunner
 
 import (
 	"testing"
@@ -6,8 +6,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// MockAgent is a mock implementation of the Agent interface.
-type MockAgent struct{}
+// mockAgentInfo is a mock AgentInfo for testing.
+func mockAgentInfo() AgentInfo {
+	return AgentInfo{
+		AgentID: "test-agent",
+		Model:   "gpt-4",
+		Prompt:  "test prompt",
+	}
+}
 
 func TestRunnerManager_Singleton(t *testing.T) {
 	rm1 := GetRunnerManager()
@@ -22,10 +28,10 @@ func TestRunnerManager_CRUD(t *testing.T) {
 	// Ensure clean state for test (though singleton persists, so we might need to clear it if tests run in same process)
 	// Since we can't easily reset the singleton once, we just work with what we have or clear the map manually.
 	rm.mu.Lock()
-	rm.runners = make(map[string]*TaskRunner)
+	rm.runners = make(map[string]*Runner)
 	rm.mu.Unlock()
 
-	agent := &MockAgent{}
+	agent := mockAgentInfo()
 	taskId := "task-1"
 
 	// Create

--- a/internal/runner/task_runner.go
+++ b/internal/runner/task_runner.go
@@ -1,4 +1,4 @@
-package runner
+package taskrunner
 
 import "context"
 
@@ -16,7 +16,7 @@ type RunRequest struct {
 	Messages     []ChatMessage
 }
 
-// ensure Runner implements TaskRunner
+// ensure Runner implements TaskRunner interface
 var _ TaskRunner = (*Runner)(nil)
 
 // Run implements TaskRunner interface.

--- a/internal/testutil/mocks/mock_runner.go
+++ b/internal/testutil/mocks/mock_runner.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/cnap-oss/app/internal/runner"
+	taskrunner "github.com/cnap-oss/app/internal/runner"
 )
 
 // MockRunner는 테스트용 TaskRunner 구현입니다.
@@ -16,7 +16,7 @@ type MockRunner struct {
 	Errors map[string]error
 
 	// Calls는 Run 호출 기록입니다.
-	Calls []*runner.RunRequest
+	Calls []*taskrunner.RunRequest
 
 	// DefaultResponse는 Responses에 없는 경우 사용할 기본 응답입니다.
 	DefaultResponse string
@@ -27,16 +27,16 @@ func NewMockRunner() *MockRunner {
 	return &MockRunner{
 		Responses:       make(map[string]string),
 		Errors:          make(map[string]error),
-		Calls:           make([]*runner.RunRequest, 0),
+		Calls:           make([]*taskrunner.RunRequest, 0),
 		DefaultResponse: "Mock response",
 	}
 }
 
 // ensure MockRunner implements TaskRunner
-var _ runner.TaskRunner = (*MockRunner)(nil)
+var _ taskrunner.TaskRunner = (*MockRunner)(nil)
 
 // Run implements TaskRunner interface.
-func (m *MockRunner) Run(ctx context.Context, req *runner.RunRequest) (*runner.RunResult, error) {
+func (m *MockRunner) Run(ctx context.Context, req *taskrunner.RunRequest) (*taskrunner.RunResult, error) {
 	// 호출 기록
 	m.Calls = append(m.Calls, req)
 
@@ -51,7 +51,7 @@ func (m *MockRunner) Run(ctx context.Context, req *runner.RunRequest) (*runner.R
 		response = resp
 	}
 
-	return &runner.RunResult{
+	return &taskrunner.RunResult{
 		Agent:   req.Model,
 		Name:    req.TaskID,
 		Success: true,
@@ -81,7 +81,7 @@ func (m *MockRunner) GetCallCount() int {
 }
 
 // GetLastCall은 마지막 Run 호출을 반환합니다.
-func (m *MockRunner) GetLastCall() *runner.RunRequest {
+func (m *MockRunner) GetLastCall() *taskrunner.RunRequest {
 	if len(m.Calls) == 0 {
 		return nil
 	}
@@ -90,5 +90,5 @@ func (m *MockRunner) GetLastCall() *runner.RunRequest {
 
 // Reset은 모든 호출 기록을 초기화합니다.
 func (m *MockRunner) Reset() {
-	m.Calls = make([]*runner.RunRequest, 0)
+	m.Calls = make([]*taskrunner.RunRequest, 0)
 }

--- a/internal/testutil/mocks/mock_runner_test.go
+++ b/internal/testutil/mocks/mock_runner_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/cnap-oss/app/internal/runner"
+	taskrunner "github.com/cnap-oss/app/internal/runner"
 	"github.com/cnap-oss/app/internal/testutil/mocks"
 	"github.com/stretchr/testify/require"
 )
@@ -14,11 +14,11 @@ func TestMockRunner_Run(t *testing.T) {
 	mock.SetResponse("task-001", "Hello from mock!")
 
 	ctx := context.Background()
-	req := &runner.RunRequest{
+	req := &taskrunner.RunRequest{
 		TaskID:       "task-001",
 		Model:        "gpt-4",
 		SystemPrompt: "You are a helpful assistant",
-		Messages: []runner.ChatMessage{
+		Messages: []taskrunner.ChatMessage{
 			{Role: "user", Content: "Hi"},
 		},
 	}
@@ -35,7 +35,7 @@ func TestMockRunner_DefaultResponse(t *testing.T) {
 	mock.DefaultResponse = "Default response"
 
 	ctx := context.Background()
-	req := &runner.RunRequest{
+	req := &taskrunner.RunRequest{
 		TaskID: "unknown-task",
 		Model:  "gpt-4",
 	}
@@ -50,7 +50,7 @@ func TestMockRunner_Error(t *testing.T) {
 	mock.SetErrorMessage("task-fail", "API error")
 
 	ctx := context.Background()
-	req := &runner.RunRequest{
+	req := &taskrunner.RunRequest{
 		TaskID: "task-fail",
 		Model:  "gpt-4",
 	}
@@ -67,9 +67,9 @@ func TestMockRunner_CallHistory(t *testing.T) {
 	ctx := context.Background()
 
 	// 여러 번 호출
-	_, _ = mock.Run(ctx, &runner.RunRequest{TaskID: "task-1"})
-	_, _ = mock.Run(ctx, &runner.RunRequest{TaskID: "task-2"})
-	_, _ = mock.Run(ctx, &runner.RunRequest{TaskID: "task-3"})
+	_, _ = mock.Run(ctx, &taskrunner.RunRequest{TaskID: "task-1"})
+	_, _ = mock.Run(ctx, &taskrunner.RunRequest{TaskID: "task-2"})
+	_, _ = mock.Run(ctx, &taskrunner.RunRequest{TaskID: "task-3"})
 
 	require.Equal(t, 3, mock.GetCallCount())
 	require.Equal(t, "task-3", mock.GetLastCall().TaskID)


### PR DESCRIPTION
Controller-RunnerManager 연동을 위한 기반 작업으로,
package 구조 및 인터페이스를 정의합니다.

## 주요 변경사항

### 1. Package 이름 통일
- `package TaskRunner` → `package taskrunner`
- `package runner` → `package taskrunner`
- Go 관례에 따라 소문자로 통일

### 2. Agent 인터페이스를 AgentInfo 구조체로 변경
- 기존: `type Agent interface{}`
- 변경: `type AgentInfo struct { AgentID, Model, Prompt string }`
- 에이전트 실행에 필요한 정보를 명시적으로 정의

### 3. StatusCallback 인터페이스 추가
- Task 실행 중 상태 변경을 Controller에 알리기 위한 콜백
- `OnStatusChange`, `OnComplete`, `OnError` 메서드 정의

### 4. TaskRunner 인터페이스와 구현체 분리
- 인터페이스: `TaskRunner` (task_runner.go)
- 구현체: `Runner` (runner.go)
- 기존 `TaskRunner` 구조체를 `Runner`로 rename

### 5. 관련 import 경로 수정
- mock 및 test 파일의 import 경로를 `taskrunner`로 alias 적용
- `github.com/cnap-oss/app/internal/runner` → `taskrunner`

## 영향 범위
- internal/runner/manager.go
- internal/runner/manager_test.go
- internal/runner/runner.go
- internal/runner/task_runner.go
- internal/testutil/mocks/mock_runner.go
- internal/testutil/mocks/mock_runner_test.go

## 테스트 결과
- 모든 단위 테스트 통과 ✅
- 통합 테스트 통과 ✅
- 빌드 성공 ✅
- Linter 통과 ✅

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)