### PR TITLE
feat(controller): Task 실행 상태 동기화 메커니즘 구현

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -238,13 +238,13 @@ func (c *Controller) CreateTask(ctx context.Context, agentID, taskID, prompt str
 		return err
 	}
 
-	// RunnerManager에 TaskRunner 생성
+	// RunnerManager에 TaskRunner 생성 (callback 주입)
 	agentInfo := taskrunner.AgentInfo{
 		AgentID: agentID,
 		Model:   agent.Model,
 		Prompt:  agent.Prompt,
 	}
-	runner := c.runnerManager.CreateRunner(taskID, agentInfo)
+	runner := c.runnerManager.CreateRunner(taskID, agentInfo, c)
 	if runner == nil {
 		return fmt.Errorf("failed to create task runner")
 	}
@@ -624,42 +624,21 @@ func (c *Controller) executeTask(ctx context.Context, taskID string, task *stora
 		Messages:     chatMessages,
 	}
 
-	// TaskRunner 실행
+	// TaskRunner 실행 (callback이 상태 변경과 결과 저장 처리)
 	result, err := runner.Run(ctx, req)
+
+	// 로그 출력
 	if err != nil {
 		c.logger.Error("TaskRunner execution failed",
 			zap.String("task_id", taskID),
 			zap.Error(err),
 		)
-		_ = c.repo.UpsertTaskStatus(ctx, taskID, task.AgentID, storage.TaskStatusFailed)
-
-		// 실행 완료 후 TaskRunner 정리
-		c.runnerManager.DeleteRunner(taskID)
-		return
+	} else {
+		c.logger.Info("Task execution completed",
+			zap.String("task_id", taskID),
+			zap.Bool("success", result != nil && result.Success),
+		)
 	}
-
-	// 결과를 파일로 저장
-	if result.Success {
-		filePath, err := c.saveMessageToFile(ctx, taskID, "assistant", result.Output)
-		if err != nil {
-			c.logger.Error("Failed to save result to file", zap.Error(err))
-		} else {
-			// MessageIndex에 추가
-			if _, err := c.repo.AppendMessageIndex(ctx, taskID, "assistant", filePath); err != nil {
-				c.logger.Error("Failed to append message index", zap.Error(err))
-			}
-		}
-	}
-
-	// 상태를 completed로 변경
-	if err := c.repo.UpsertTaskStatus(ctx, taskID, task.AgentID, storage.TaskStatusCompleted); err != nil {
-		c.logger.Error("Failed to update task status to completed", zap.Error(err))
-	}
-
-	c.logger.Info("Task execution completed",
-		zap.String("task_id", taskID),
-		zap.Bool("success", result.Success),
-	)
 
 	// 실행 완료 후 TaskRunner 정리
 	c.runnerManager.DeleteRunner(taskID)
@@ -740,4 +719,56 @@ func (c *Controller) saveMessageToFile(ctx context.Context, taskID, role, conten
 
 	return filePath, nil
 }
+
+// StatusCallback 인터페이스 구현
+
+// OnStatusChange는 Task 상태가 변경될 때 호출됩니다.
+func (c *Controller) OnStatusChange(taskID string, status string) error {
+	c.logger.Debug("OnStatusChange callback",
+		zap.String("task_id", taskID),
+		zap.String("status", status),
+	)
+
+	return c.UpdateTaskStatus(context.Background(), taskID, status)
+}
+
+// OnComplete는 Task가 완료될 때 호출됩니다.
+func (c *Controller) OnComplete(taskID string, result *taskrunner.RunResult) error {
+	c.logger.Info("OnComplete callback",
+		zap.String("task_id", taskID),
+		zap.Bool("success", result.Success),
+	)
+
+	// 결과를 파일로 저장
+	if result.Success {
+		filePath, err := c.saveMessageToFile(context.Background(), taskID, "assistant", result.Output)
+		if err != nil {
+			c.logger.Error("Failed to save result to file", zap.Error(err))
+			return err
+		}
+
+		// MessageIndex에 추가
+		if _, err := c.repo.AppendMessageIndex(context.Background(), taskID, "assistant", filePath); err != nil {
+			c.logger.Error("Failed to append message index", zap.Error(err))
+			return err
+		}
+	}
+
+	// 상태를 completed로 변경
+	return c.UpdateTaskStatus(context.Background(), taskID, storage.TaskStatusCompleted)
+}
+
+// OnError는 Task 실행 중 에러가 발생할 때 호출됩니다.
+func (c *Controller) OnError(taskID string, err error) error {
+	c.logger.Error("OnError callback",
+		zap.String("task_id", taskID),
+		zap.Error(err),
+	)
+
+	// 상태를 failed로 변경
+	return c.UpdateTaskStatus(context.Background(), taskID, storage.TaskStatusFailed)
+}
+
+// ensure Controller implements StatusCallback
+var _ taskrunner.StatusCallback = (*Controller)(nil)
 

--- a/internal/runner/manager.go
+++ b/internal/runner/manager.go
@@ -26,13 +26,14 @@ func GetRunnerManager() *RunnerManager {
 }
 
 // CreateRunner creates a new Runner and adds it to the manager.
-func (rm *RunnerManager) CreateRunner(taskId string, agent AgentInfo) *Runner {
+func (rm *RunnerManager) CreateRunner(taskId string, agent AgentInfo, callback StatusCallback) *Runner {
 	rm.mu.Lock()
 	defer rm.mu.Unlock()
 
 	runner := &Runner{
-		ID:     taskId,
-		Status: "Pending", // Initial status
+		ID:       taskId,
+		Status:   "Pending", // Initial status
+		callback: callback,
 		// Initialize other fields if needed
 	}
 	rm.runners[taskId] = runner

--- a/internal/runner/manager_test.go
+++ b/internal/runner/manager_test.go
@@ -34,8 +34,8 @@ func TestRunnerManager_CRUD(t *testing.T) {
 	agent := mockAgentInfo()
 	taskId := "task-1"
 
-	// Create
-	runner := rm.CreateRunner(taskId, agent)
+	// Create (with nil callback for testing)
+	runner := rm.CreateRunner(taskId, agent, nil)
 	assert.NotNil(t, runner)
 	assert.Equal(t, taskId, runner.ID)
 	assert.Equal(t, "Pending", runner.Status)

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -35,10 +35,11 @@ type StatusCallback interface {
 
 // Runner는 short-living 에이전트 실행을 담당하는 TaskRunner 구현체입니다.
 type Runner struct {
-	ID     string
-	Status string
-	logger *zap.Logger
-	apiKey string
+	ID       string
+	Status   string
+	logger   *zap.Logger
+	apiKey   string
+	callback StatusCallback
 }
 
 // OpenCodeRequest는 OpenCode Zen API 요청 바디입니다.

--- a/internal/runner/task_runner.go
+++ b/internal/runner/task_runner.go
@@ -40,5 +40,19 @@ func (r *Runner) Run(ctx context.Context, req *RunRequest) (*RunResult, error) {
 		}
 	}
 
-	return r.RunWithResult(ctx, req.Model, req.TaskID, prompt)
+	// API 호출
+	result, err := r.RunWithResult(ctx, req.Model, req.TaskID, prompt)
+
+	// 에러 발생 시 callback 호출
+	if err != nil && r.callback != nil {
+		_ = r.callback.OnError(req.TaskID, err)
+		return nil, err
+	}
+
+	// 성공 시 callback 호출
+	if result != nil && r.callback != nil {
+		_ = r.callback.OnComplete(req.TaskID, result)
+	}
+
+	return result, nil
 }


### PR DESCRIPTION
TaskRunner 실행 중 상태 변경사항을 Controller와 동기화하는
Callback 패턴을 구현했습니다.

## 주요 변경사항

### 1. Controller가 StatusCallback 인터페이스 구현
- `OnStatusChange`: Task 상태 변경 시 호출
- `OnComplete`: Task 완료 시 결과 저장 및 상태 업데이트
- `OnError`: Task 실행 중 에러 발생 시 failed 상태로 전환

### 2. Runner 구조체에 callback 필드 추가
```go
type Runner struct {
    ID       string
    Status   string
    logger   *zap.Logger
    apiKey   string
    callback StatusCallback  // 추가
}
```

### 3. CreateRunner에서 callback 주입
- RunnerManager.CreateRunner() 메서드 시그니처 변경
- Controller를 callback으로 주입하여 상태 변경 알림 가능

### 4. Runner.Run에서 상태 변경 알림 구현
- API 호출 성공 시 `OnComplete` 호출
- API 호출 실패 시 `OnError` 호출
- Callback이 결과 저장 및 상태 업데이트 처리

### 5. executeTask 메서드 간소화
- Callback이 상태 변경과 결과 저장을 처리하므로 중복 코드 제거
- TaskRunner 실행 완료 후 정리만 담당

## 상태 전이 규칙

```
pending → running → completed (성공)
pending → running → failed    (에러)
```

## 영향 범위
- internal/controller/controller.go
- internal/runner/runner.go
- internal/runner/task_runner.go
- internal/runner/manager.go
- internal/runner/manager_test.go

## 테스트 결과
- ✅ 모든 단위 테스트 통과
- ✅ 통합 테스트 통과
- ✅ 빌드 성공
- ✅ Linter 통과 (0 issues)

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)